### PR TITLE
feat: copy permissions from one resource group to another source group

### DIFF
--- a/Azure_PowerShell/AZ_RG_Copy_Permissons_per_RG_interactive.os1
+++ b/Azure_PowerShell/AZ_RG_Copy_Permissons_per_RG_interactive.os1
@@ -1,0 +1,13 @@
+# Prompt the user for the source resource group name
+$resourceRG = Read-Host "Enter the source resource group name"
+
+# Prompt the user for the target resource group name
+$resourceRG = Read-Host "Enter the source resource group name"
+
+# Get all the role assignments from the source resource group
+$roleAssignments = Get-AzRoleAssignment -ResourceGroupName $sourceRG
+
+# Loop through each role assignment and assign the same role to the target resource group
+foreach ($assignment in $roleAssignments) {
+    New-AzRoleAssignment -ObjectId $assignment.ObjectId -RoleDefinitionName $assignment.RoleDefinitionName -ResourceGroupName $targetRG
+}


### PR DESCRIPTION
allows easily for copying permissions from one Azure resource group to another as we can't rename existing Azure resource groups